### PR TITLE
Refactor/fast masked geno

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: HAUDI
 Title: Efficient Lasso Framework for Admixture-Aware Polygenic Risk Scores
-Version: 1.0.9
+Version: 1.0.10
 Authors@R: 
   person("Franklin", "Ockerman", , "frankpo@unc.edu", role = c("aut", "cre"))
 Description: HAUDI is an R package for constructing polygenic scores

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## HAUDI 1.0.10
+
+- Now use Rcpp to construct ancestry-masked genotypes
+
 ## HAUDI 1.0.9
 
 - Fix bugs in ancestry queries (wrong variant indices and incorrect sample subsetting)

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -9,6 +9,10 @@ rcpp_query_tracts <- function(left_haps, right_haps, breakpoints, offsets, indic
     .Call(`_HAUDI_rcpp_query_tracts`, left_haps, right_haps, breakpoints, offsets, indices)
 }
 
+rcpp_get_masked_geno <- function(anc0, anc1, gen0, gen1, n_anc) {
+    .Call(`_HAUDI_rcpp_get_masked_geno`, anc0, anc1, gen0, gen1, n_anc)
+}
+
 rcpp_read_rfmix <- function(msp_file) {
     .Call(`_HAUDI_rcpp_read_rfmix`, msp_file)
 }

--- a/R/fbm.R
+++ b/R/fbm.R
@@ -124,11 +124,7 @@ make_haudi_chunk <- function(chunk, pgen, pvar, tracts,
   }
 
   ## Per-ancestry genotypes and total genotypes
-  mat_haudi <- lapply(0:(length(anc_names) - 1), function(anc) {
-    gen0 * (anc_mats$hap0 == anc) + gen1 * (anc_mats$hap1 == anc)
-  }) |>
-    do.call(what = "cbind") |>
-    cbind(gen0 + gen1)
+  mat_haudi <- rcpp_get_masked_geno(anc_mats$hap0, anc_mats$hap1, gen0, gen1, length(anc_names))
 
   dt_info <- data.table::data.table(
     chrom = rep(pvar[chunk, ]$`#CHROM`, length(anc_names) + 1),

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -36,6 +36,21 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// rcpp_get_masked_geno
+NumericMatrix rcpp_get_masked_geno(IntegerMatrix anc0, IntegerMatrix anc1, NumericMatrix gen0, NumericMatrix gen1, int n_anc);
+RcppExport SEXP _HAUDI_rcpp_get_masked_geno(SEXP anc0SEXP, SEXP anc1SEXP, SEXP gen0SEXP, SEXP gen1SEXP, SEXP n_ancSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< IntegerMatrix >::type anc0(anc0SEXP);
+    Rcpp::traits::input_parameter< IntegerMatrix >::type anc1(anc1SEXP);
+    Rcpp::traits::input_parameter< NumericMatrix >::type gen0(gen0SEXP);
+    Rcpp::traits::input_parameter< NumericMatrix >::type gen1(gen1SEXP);
+    Rcpp::traits::input_parameter< int >::type n_anc(n_ancSEXP);
+    rcpp_result_gen = Rcpp::wrap(rcpp_get_masked_geno(anc0, anc1, gen0, gen1, n_anc));
+    return rcpp_result_gen;
+END_RCPP
+}
 // rcpp_read_rfmix
 DataFrame rcpp_read_rfmix(std::string msp_file);
 RcppExport SEXP _HAUDI_rcpp_read_rfmix(SEXP msp_fileSEXP) {
@@ -51,6 +66,7 @@ END_RCPP
 static const R_CallMethodDef CallEntries[] = {
     {"_HAUDI_rcpp_read_flare", (DL_FUNC) &_HAUDI_rcpp_read_flare, 1},
     {"_HAUDI_rcpp_query_tracts", (DL_FUNC) &_HAUDI_rcpp_query_tracts, 5},
+    {"_HAUDI_rcpp_get_masked_geno", (DL_FUNC) &_HAUDI_rcpp_get_masked_geno, 5},
     {"_HAUDI_rcpp_read_rfmix", (DL_FUNC) &_HAUDI_rcpp_read_rfmix, 1},
     {NULL, NULL, 0}
 };

--- a/src/lanc.cpp
+++ b/src/lanc.cpp
@@ -39,3 +39,56 @@ List rcpp_query_tracts(const IntegerVector &left_haps,
 
   return List::create(_["hap0"] = left_out, _["hap1"] = right_out);
 }
+
+// [[Rcpp::export]]
+NumericMatrix rcpp_get_masked_geno(IntegerMatrix anc0, IntegerMatrix anc1,
+                                   NumericMatrix gen0, NumericMatrix gen1,
+                                   int n_anc) {
+  int n_samp = anc0.nrow();
+  int n_var = anc0.ncol();
+
+  NumericMatrix out(n_samp, n_var * n_anc + n_var);
+
+  const int *p_anc0 = INTEGER(anc0);
+  const int *p_anc1 = INTEGER(anc1);
+  const double *p_gen0 = REAL(gen0);
+  const double *p_gen1 = REAL(gen1);
+  double *p_out = REAL(out);
+
+  // ancestry blocks
+  for (int anc = 0; anc < n_anc; ++anc) {
+    int offset = anc * n_var;
+
+    for (int j = 0; j < n_var; ++j) {
+
+      const int *h0 = p_anc0 + j * n_samp;
+      const int *h1 = p_anc1 + j * n_samp;
+      const double *g0 = p_gen0 + j * n_samp;
+      const double *g1 = p_gen1 + j * n_samp;
+
+      double *out_col = p_out + (offset + j) * n_samp;
+
+      for (int i = 0; i < n_samp; ++i) {
+        double v = 0.0;
+        if (h0[i] == anc)
+          v += g0[i];
+        if (h1[i] == anc)
+          v += g1[i];
+        out_col[i] = v;
+      }
+    }
+  }
+
+  int final_offset = n_var * n_anc;
+
+  for (int j = 0; j < n_var; ++j) {
+    const double *g0 = p_gen0 + j * n_samp;
+    const double *g1 = p_gen1 + j * n_samp;
+    double *out_col = p_out + (final_offset + j) * n_samp;
+
+    for (int i = 0; i < n_samp; ++i)
+      out_col[i] = g0[i] + g1[i];
+  }
+
+  return out;
+}


### PR DESCRIPTION
Now use Rcpp to construct ancestry-masked genotypes. This should substantially improve the speed of constructing an FBM.